### PR TITLE
import networkLite and define as.networkDynamic.networkLite

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 Change Log:
+v0.11.3
+  - import networkLite and define as.networkDynamic.networkLite to support tergm applications
 v0.11.2
   - corrected trailing quote in maintainer email flagged by CRAN
 v0.11.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: networkDynamic
-Version: 0.11.2
+Version: 0.11.3
 Date: 2022-05-04
 Title: Dynamic Extensions for Network Objects
 Type: Package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,3 @@ Description: Simple interface routines to facilitate the handling of network obj
 License: GPL-3
 LazyLoad: yes
 URL: http://statnet.org
-Remotes:
-    github::EpiModel/networkLite@networkLite

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,5 @@ Description: Simple interface routines to facilitate the handling of network obj
 License: GPL-3
 LazyLoad: yes
 URL: http://statnet.org
+Remotes:
+    github::EpiModel/networkLite@networkLite

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Date: 2022-05-04
 Title: Dynamic Extensions for Network Objects
 Type: Package
 Depends: R (>= 3.0.0), network (>= 1.17.0)
-Imports: statnet.common, methods
+Imports: statnet.common, methods, networkLite
 Suggests: testthat
 LinkingTo: network
 Authors@R: c(

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
 useDynLib(networkDynamic, .registration = TRUE)
 
-import(statnet.common, network)
+import(statnet.common, network, networkLite)
 importFrom("methods", "el")
 importFrom("methods", "is")
 importFrom("stats", "na.omit")
@@ -90,6 +90,7 @@ S3method(as.network,networkDynamic)
 S3method(as.networkDynamic,network)
 S3method(as.networkDynamic,networkDynamic)
 S3method(print,networkDynamic)
+S3method(as.networkDynamic,networkLite)
 
 # these are NOT S3 methods, but are included here because its the 
 # only way to quiet the warning

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1042,6 +1042,10 @@ as.networkDynamic.network<- function(object,...){
   return(object)
 }
 
+as.networkDynamic.networkLite <- function(object, ...) {
+  as.networkDynamic(to_network_networkLite(object))
+}
+
 # remove networkDynamic class but leave object unchanged
 as.network.networkDynamic<-function(x,...){
   if(is.networkDynamic(x)){

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -11,15 +11,18 @@
 \alias{as.networkDynamic}
 \alias{as.networkDynamic.network}
 \alias{as.networkDynamic.networkDynamic}
+\alias{as.networkDynamic.networkLite}
 
 \title{
 as.networkDynamic
 }
 \description{
-Functions with these names formerly provided S3-dispatched functions for converting between various dynamic network formats which have been DEPRECATED. Use \code{\link{networkDynamic}} instead. Current application only sets the networkDynamic class on objects. 
+The \code{as.networkDynamic} generic provides basic conversion to 
+\code{networkDynamic} from other network types. Where possible, it is 
+recommended to use the \code{\link{networkDynamic}} function instead of 
+\code{as.networkDynamic}, because \code{\link{networkDynamic}} provides a 
+number of additional features for handling temporal information.
 }
-
-
 
 \usage{
                  
@@ -27,26 +30,39 @@ Functions with these names formerly provided S3-dispatched functions for convert
 
 \method{as.networkDynamic}{network}(object,...)
 
+\method{as.networkDynamic}{networkLite}(object,...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{object}{a \code{network} or \code{networkDynamic} object}
+  \item{object}{a \code{network}, \code{networkLite}, or \code{networkDynamic} object}
 
   \item{\dots}{ignored}
 
 }
 \details{
- \code{as.networkDynamic.network} converts a network object into networkDynamic object by adding a \code{networkDynamic} class.
+ \code{as.networkDynamic.network} converts a \code{network} object into 
+ a \code{networkDynamic} object by adding a \code{networkDynamic} class.
+ 
+ \code{as.networkDynamic.networkLite} converts a \code{networkLite} object into 
+ a \code{networkDynamic} object by first converting it to a \code{network} 
+ object and then adding a \code{networkDynamic} class.
+
+ Such conversions between network types are used when starting a dynamic 
+ simulation from a cross-sectional network and returning the simulation history 
+ as a dynamic network, as done in the \code{tergm} package for example.
 }
 
-
-
 \value{
-  For \code{as.networkDynamic.network} the input object is returned with a \code{networkDynamic} class added.  For \code{as.networkDynamic.networkDynamic} the input object is returned. 
+  For \code{as.networkDynamic.network} the input object is returned with a 
+  \code{networkDynamic} class added. For \code{as.networkDynamic.networkLite}, 
+  the input object is converted to a \code{network} object and then the 
+  \code{networkDynamic} class is added. For 
+  \code{as.networkDynamic.networkDynamic} the input object is returned 
+  unchanged.
 }
 
 \note{
-Function modifies its argument
+The \code{network} method modifies its argument.
 }
 
 \author{
@@ -54,11 +70,19 @@ Pavel, Zack W Almquist <almquist@uci.edu>
 }
 %% ~Make other sections like Warning with \section{Warning }{....} ~
 \seealso{
-For previous functionality, see  \code{\link{networkDynamic}}. For the inverse (removing networkDynamic class) see \code{\link{as.network.networkDynamic}}.
+For more general construction of \code{networkDynamic}s, see 
+\code{\link{networkDynamic}}. For the inverse (removing \code{networkDynamic} 
+class) see \code{\link{as.network.networkDynamic}} and 
+\code{\link{as.networkLite.network}} (which applies to \code{networkDynamic}s).
 }
 
 \examples{
- nd<-as.networkDynamic(network.initialize(3))
+ nd <- as.networkDynamic(network.initialize(3))
  class(nd)
  is.networkDynamic(nd)
+ 
+ nwL <- networkLite::networkLite(3)
+ nwD <- as.networkDynamic(nwL)
+ class(nwD)
+ is.networkDynamic(nwD)
 }

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -48,7 +48,11 @@ number of additional features for handling temporal information.
  a \code{networkDynamic} object by first converting it to a \code{network} 
  object and then adding a \code{networkDynamic} class. (\code{networkLite}s are
  a backend data structure used in some \code{EpiModel} and \code{statnet}
- packages, and are not typically handled directly by the end user.)
+ packages, providing improved performance for certain applications, especially
+ when working with vertex and edge attributes that can be stored as atomic
+ vectors. Currently, \code{networkLite}s come with the restriction that the
+ network attributes \code{hyper}, \code{multiple}, and \code{loops} must be
+ \code{FALSE}. See \code{\link{networkLite-package}} for more information.)
 
  Such conversions between network types are used when starting a dynamic 
  simulation from a cross-sectional network and returning the simulation history 

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -16,10 +16,11 @@
 \title{
 as.networkDynamic
 }
+
 \description{
-The \code{as.networkDynamic} generic provides basic conversion to 
-\code{networkDynamic} from other network types. Where possible, it is 
-recommended to use the \code{\link{networkDynamic}} function instead of 
+The \code{as.networkDynamic} generic provides a very basic conversion to 
+\code{networkDynamic} from other network types. It is generally recommended 
+to use the \code{\link{networkDynamic}} function instead of 
 \code{as.networkDynamic}, because \code{\link{networkDynamic}} provides a 
 number of additional features for handling temporal information.
 }
@@ -45,7 +46,9 @@ number of additional features for handling temporal information.
  
  \code{as.networkDynamic.networkLite} converts a \code{networkLite} object into 
  a \code{networkDynamic} object by first converting it to a \code{network} 
- object and then adding a \code{networkDynamic} class.
+ object and then adding a \code{networkDynamic} class. (\code{networkLite}s are
+ a backend data structure used in some \code{EpiModel} and \code{statnet}
+ packages, and are not typically handled directly by the end user.)
 
  Such conversions between network types are used when starting a dynamic 
  simulation from a cross-sectional network and returning the simulation history 

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -64,10 +64,6 @@ number of additional features for handling temporal information.
   unchanged.
 }
 
-\note{
-The \code{network} method modifies its argument.
-}
-
 \author{
 Pavel, Zack W Almquist <almquist@uci.edu>
 }

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -73,10 +73,14 @@ Pavel, Zack W Almquist <almquist@uci.edu>
 }
 %% ~Make other sections like Warning with \section{Warning }{....} ~
 \seealso{
-For more general construction of \code{networkDynamic}s, see 
-\code{\link{networkDynamic}}. For the inverse (removing \code{networkDynamic} 
-class) see \code{\link{as.network.networkDynamic}} and 
+For the inverse (removing the \code{networkDynamic} class) see
+\code{\link{as.network.networkDynamic}} and
 \code{\link{as.networkLite.network}} (which applies to \code{networkDynamic}s).
+For extracting cross-sectional information from a \code{networkDynamic} (which
+is often more appropriate than simply removing the \code{networkDynamic}
+class), see \code{\link{network.collapse}} and \code{\link{network.extract}}.
+For more general construction of \code{networkDynamic}s, see
+\code{\link{networkDynamic}}. 
 }
 
 \examples{

--- a/tests/utils_tests.R
+++ b/tests/utils_tests.R
@@ -89,3 +89,24 @@ test_that("get.dyads.active works",{
   
 })
 
+test_that("conversions between network, networkLite, and networkDynamic behave as expected", {
+  library(networkLite)
+  
+  m <- matrix(rbinom(20*20, 1, 1/10), nrow = 20, ncol = 20)
+  m[lower.tri(m, diag = TRUE)] <- FALSE
+  el <- which(m > 0, arr.ind = TRUE)
+  el <- el[order(el[,1], el[,2]),,drop=FALSE]
+  attr(el, "n") <- 20
+  
+  nw <- network(el, directed = FALSE, bipartite = FALSE, matrix.type = "edgelist")
+  nwL <- as.networkLite(nw)
+  nwLD <- as.networkDynamic(nwL)
+  nwD <- as.networkDynamic(nw)
+  expect_identical(nwD, nwLD)
+  
+  nwL <- networkLite(el)
+  nw <- to_network_networkLite(nwL)
+  nwD <- as.networkDynamic(nw)
+  nwLD <- as.networkDynamic(nwL)
+  expect_identical(nwD, nwLD)
+})

--- a/tests/utils_tests.R
+++ b/tests/utils_tests.R
@@ -91,22 +91,26 @@ test_that("get.dyads.active works",{
 
 test_that("conversions between network, networkLite, and networkDynamic behave as expected", {
   library(networkLite)
-  
+
   m <- matrix(rbinom(20*20, 1, 1/10), nrow = 20, ncol = 20)
   m[lower.tri(m, diag = TRUE)] <- FALSE
   el <- which(m > 0, arr.ind = TRUE)
   el <- el[order(el[,1], el[,2]),,drop=FALSE]
   attr(el, "n") <- 20
-  
+
   nw <- network(el, directed = FALSE, bipartite = FALSE, matrix.type = "edgelist")
   nwL <- as.networkLite(nw)
   nwLD <- as.networkDynamic(nwL)
   nwD <- as.networkDynamic(nw)
+  nwDL <- as.networkLite(nwD)
   expect_identical(nwD, nwLD)
-  
+  expect_identical(nwDL, nwL)
+
   nwL <- networkLite(el)
   nw <- to_network_networkLite(nwL)
   nwD <- as.networkDynamic(nw)
   nwLD <- as.networkDynamic(nwL)
+  nwDL <- as.networkLite(nwD)
   expect_identical(nwD, nwLD)
+  expect_identical(nwDL, nwL)
 })


### PR DESCRIPTION
This PR imports the (new) `networkLite` package and defines `as.networkDynamic.networkLite` (which is needed to support `tergm` applications of `networkLite`s).  This will permit e.g. `ergm` to import `networkLite` without depending on `networkDynamic`.  Version number and ChangeLog have been updated.