### PR TITLE
Paj examples workaround fix #24

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 Change Log:
+v0.11.5
+  - update links to .paj example files and fix some documentation warnings
 v0.11.4
   - correct documentation and compiler warnings flagged by CRAN. Some documentation updates.
 v0.11.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: networkDynamic
-Version: 0.11.4
-Date: 2023-12-10?
+Version: 0.11.5
+Date: 2024-11-21
 Title: Dynamic Extensions for Network Objects
 Type: Package
 Depends: R (>= 3.0.0), network (>= 1.17.0)

--- a/man/Newcomb.Rd
+++ b/man/Newcomb.Rd
@@ -41,7 +41,7 @@ men to the \eqn{j}th man if \eqn{i} had a preference for
 to \eqn{j}. Note that since these are ranks, the degree of each vertex (and the total number of edges) does not vary over time
 }
 \usage{data(newcomb)}
-\source{\url{http://vlado.fmf.uni-lj.si/pub/networks/data/ucinet/ucidata.htm#newfrat}}
+\source{\url{https://github.com/bavla/Nets/tree/master/data/Pajek/ucinet#-newcomb-fraternity}}
 \references{See the link above. 
 Newcomb T. (1961). The acquaintance process. New York: Holt, Reinhard and Winston.\\
 Nordlie P. (1958). A longitudinal study of interpersonal attraction in a natural group setting. Unpublished doctoral dissertation, University of Michigan.\\
@@ -67,7 +67,7 @@ and the source should be cited as:
 
 Vladimir Batagelj and Andrej Mrvar (2006): \emph{Pajek datasets}
 \cr
-\url{http://vlado.fmf.uni-lj.si/pub/networks/data/} 
+\url{https://github.com/bavla/Nets/tree/master/data/Pajek/} 
 }
 \examples{
 data(newcomb)

--- a/man/add.active.Rd
+++ b/man/add.active.Rd
@@ -24,7 +24,7 @@ Convenience functions for adding a set of verticies (or edges) and setting them 
          onset = NULL, terminus = NULL, length = NULL, at = NULL, ...)
 }
 \arguments{
-  \item{x}{ an object of class \code{\link{network}} or \code{\link{networkDynamic}}. }
+  \item{x}{ an object of class \code{\link[network]{network}} or \code{\link{networkDynamic}}. }
   \item{nv}{the number of vertices to add}
   \item{tail}{a vector of vertex IDs corresponding to the tail (source, ego) of each edge to be added}
   \item{head}{a vector of vertex IDs corresponding to the head (target, alter) of each edge to be added}
@@ -33,14 +33,14 @@ Convenience functions for adding a set of verticies (or edges) and setting them 
   \item{terminus}{ an optional vector of time points that specifies the ends of the interval(s). This must be accompanied by one of \code{onset} or \code{length}. }
   \item{length}{ an optional vector of interval lengths for the interval(s). This must be accompanied by one of \code{onset} or \code{terminus}. }
   \item{at}{ optional, one or more time points to be activated. }
-  \item{names.eval}{optional list of length equal to the number of edges, with each element containing a list of names for the attributes of the corresponding edge. not currently interpreted in a dynamic context, but passed directly to \code{\link{add.edges}}}
-  \item{vals.eval}{an optional list of lists of edge attribute values (matching \code{names.eval}). Not currently interpreted in a dynamic context, but passed directly to \code{\link{add.edges}}}
-  \item{vattr}{optionally, a list of attributes with one entry per new vertex. not currently interpreted in a dynamic context, but passed directly to \code{\link{add.vertices}}}
+  \item{names.eval}{optional list of length equal to the number of edges, with each element containing a list of names for the attributes of the corresponding edge. not currently interpreted in a dynamic context, but passed directly to \code{\link[network]{add.edges}}}
+  \item{vals.eval}{an optional list of lists of edge attribute values (matching \code{names.eval}). Not currently interpreted in a dynamic context, but passed directly to \code{\link[network]{add.edges}}}
+  \item{vattr}{optionally, a list of attributes with one entry per new vertex. not currently interpreted in a dynamic context, but passed directly to \code{\link[network]{add.vertices}}}
   \item{last.mode}{logical; should the new vertices be added to the last (rather than the first) mode of a bipartite network?}
   \item{...}{possible future additional arguments}
 }
 \details{
-Essentially a wrapper for a call to \code{\link{add.vertices}} and \code{\link{activate.vertices}}  or \code{\link{add.edges}} and \code{\link{activate.edges}} when setting up a network object. These are not the S3 methods that their name appears to imply, since there is no "active" class.  See \code{\link{add.edges.networkDynamic}}, etc.
+Essentially a wrapper for a call to \code{\link[network]{add.vertices}} and \code{\link{activate.vertices}}  or \code{\link[network]{add.edges}} and \code{\link{activate.edges}} when setting up a network object. These are not the S3 methods that their name appears to imply, since there is no "active" class.  See \code{\link{add.edges.networkDynamic}}, etc.
 }
 \value{
 The passed in network object with class set to \code{\link{networkDynamic}} and the specified number of new vertices or edges added and activated
@@ -53,7 +53,7 @@ Ayn Leslie-Cook \email{aynlc3@uw.edu}}
 
 
 \seealso{
- See Also as \code{\link{activate.vertices}}, \code{\link{activate.edges}},\code{\link{add.vertices}},\code{\link{add.edges}}
+ See Also as \code{\link{activate.vertices}}, \code{\link{activate.edges}},\code{\link[network]{add.vertices}},\code{\link[network]{add.edges}}
 }
 \examples{
 nw <- network.initialize(5)

--- a/man/age.at.Rd
+++ b/man/age.at.Rd
@@ -51,7 +51,7 @@ logical, if \code{TRUE} edges or vertices with no activity specified will be con
 \details{
 Edges or vertices that are not active at time \code{at} will return \code{NA}. For edges or vertices with multiple activity spells, this function \emph{does not} report the total duration of activity across all spells, only the duration from the start of the spell with which the \code{at} point intersects. 
 
-\code{dyads.age.at} reports the age of edges corresponding to each dyad (tail,head).  It cannot be used with hypergraphic or multiplex networks because a pair of vertex ids may not uniquely correspond to an edge. If \code{tails} and \code{heads} are not specified, they will default to the tails and heads of all existing (but not necessarily active) edges in the network.  Ordering and index position should correspond to \code{\link{valid.eids}}.
+\code{dyads.age.at} reports the age of edges corresponding to each dyad (tail,head).  It cannot be used with hypergraphic or multiplex networks because a pair of vertex ids may not uniquely correspond to an edge. If \code{tails} and \code{heads} are not specified, they will default to the tails and heads of all existing (but not necessarily active) edges in the network.  Ordering and index position should correspond to \code{\link[network]{valid.eids}}.
 }
 \value{
 By default, a numeric vector indicating the age of the network element at the query time point, or NA if the element is not active or (in the case of edges) deleted. Elements of the vector return correspond to the values of \code{e} or \code{v} or \code{(tails,heads)} respectively. 

--- a/man/as.networkDynamic.Rd
+++ b/man/as.networkDynamic.Rd
@@ -52,7 +52,7 @@ number of additional features for handling temporal information.
  when working with vertex and edge attributes that can be stored as atomic
  vectors. Currently, \code{networkLite}s come with the restriction that the
  network attributes \code{hyper}, \code{multiple}, and \code{loops} must be
- \code{FALSE}. See \code{\link{networkLite-package}} for more information.)
+ \code{FALSE}. See \code{\link[networkLite]{networkLite-package}} for more information.)
 
  Such conversions between network types are used when starting a dynamic 
  simulation from a cross-sectional network and returning the simulation history 
@@ -75,7 +75,7 @@ Pavel, Zack W Almquist <almquist@uci.edu>
 \seealso{
 For the inverse (removing the \code{networkDynamic} class) see
 \code{\link{as.network.networkDynamic}} and
-\code{\link{as.networkLite.network}} (which applies to \code{networkDynamic}s).
+\code{\link[networkLite]{as.networkLite.network}} (which applies to \code{networkDynamic}s).
 For extracting cross-sectional information from a \code{networkDynamic} (which
 is often more appropriate than simply removing the \code{networkDynamic}
 class), see \code{\link{network.collapse}} and \code{\link{network.extract}}.

--- a/man/is.active.Rd
+++ b/man/is.active.Rd
@@ -60,7 +60,7 @@ Thus [onset, terminus) will be interpreted as [onset, terminus] when terminus = 
 	\item Queries for intervals specified by \code{c(Inf, Inf)} or \code{c(-Inf, -Inf)} are ignored.
 	}
   
- If the \code{e} argument includes edge ids corresponding to deleted edges, a warning will be generated because the length of the output vector will not match the vector of edge ids.  In this case it is a good idea to use \code{\link{valid.eids}} to determine the edge ids.
+ If the \code{e} argument includes edge ids corresponding to deleted edges, a warning will be generated because the length of the output vector will not match the vector of edge ids.  In this case it is a good idea to use \code{\link[network]{valid.eids}} to determine the edge ids.
 }
 \value{
   A logical vector indicating the activity states of vertices or edges.  In the case of vertices, the elements of the vector correspond to the vertex ids provided via the \code{v} paramter.  In the edges case, if the network has deleted edges, they will be omited from the result so the elements of the vector may not correspond to the eids provided via the \code{e} parameter.
@@ -71,7 +71,7 @@ Thus [onset, terminus) will be interpreted as [onset, terminus] when terminus = 
 %
 % ~Make other sections like Warning with \section{Warning }{....} ~
 %}
-\seealso{ \code{\link{activity.attribute}}, \code{\link{activate}}, \code{\link{valid.eids}} }
+\seealso{ \code{\link{activity.attribute}}, \code{\link{activate}}, \code{\link[network]{valid.eids}} }
 \examples{
 triangle <- network.initialize(3)  # create a toy network
 add.edge(triangle,1,2)    # add an edge between vertices 1 and 2

--- a/man/network.extensions.Rd
+++ b/man/network.extensions.Rd
@@ -20,7 +20,7 @@
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{ Dynamically Extended Core Network Functions }
 \description{
-  Various core functions from the \link{network} package, with specialized extensions for handling dynamic data.
+  Various core functions from the \link[network]{network} package, with specialized extensions for handling dynamic data.
 }
 \usage{
 get.edgeIDs.active(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,

--- a/man/persistent_ids.Rd
+++ b/man/persistent_ids.Rd
@@ -54,7 +54,7 @@ The function \code{initialize.pids} can be used to create a set of pids on all e
 
 The element addition functions (\code{add.vertices}) override their network-package counterparts in order to permit assigning pids to newly-added elements if the pid is defined.  They can be defined by the user with the \code{vertex.pids} argument, or, if not specified, a unique random id will be generated. (Note that any new values added by default to a \code{vertex.names} pid will not be numeric.)
 
-Some of the import/conversion methods may set pids. See \code{\link{network}}.
+Some of the import/conversion methods may set pids. See \code{\link[network]{network}}.
 
 User-specified pids are checked for uniqueness. The the current auto-generated pid implementation produces ids that are unique within the current network.  They are also \emph{almost} certain to be unique within an R session (so that vertices will have a unique id if added and removed) and quite likely across sessions, but we need more details on the \code{tempfile}'s implementation.
 

--- a/man/print.networkDynamic.Rd
+++ b/man/print.networkDynamic.Rd
@@ -45,7 +45,7 @@ Only prints out the network information without any dynamic data.
 %% ~Make other sections like Warning with \section{Warning }{....} ~
 
 \seealso{
- \code{\link{print.network}}
+ \code{\link[network]{print.network}}
 }
 \examples{
   library(networkDynamic)

--- a/man/tea_functions.Rd
+++ b/man/tea_functions.Rd
@@ -220,7 +220,7 @@ Attribute activity is only checked against vertex and edge activity during fetch
 
 
 \seealso{
-See Also as \code{\link{set.vertex.attribute}}, \code{\link{get.vertex.attribute}},\code{\link{list.vertex.attributes}},\code{\link{activate.vertices}}, \code{\link{activity.attribute}}, \code{\link{activate}}
+See Also as \code{\link[network]{set.vertex.attribute}}, \code{\link[network]{get.vertex.attribute}},\code{\link[network]{list.vertex.attributes}},\code{\link{activate.vertices}}, \code{\link{activity.attribute}}, \code{\link{activate}}
 }
 \examples{
 #initialize network

--- a/vignettes/networkDynamic.Rnw
+++ b/vignettes/networkDynamic.Rnw
@@ -556,7 +556,7 @@ Version 1.13 of the \verb@network@ package expanded support for reading the .net
 
 <<download_paj>>=
 sampFile<-tempfile('days',fileext='.zip')
-download.file('http://vlado.fmf.uni-lj.si/pub/networks/data/esna/Sampson.zip',sampFile)
+download.file('https://github.com/bavla/Nets/raw/refs/heads/master/data/Pajek/esna/Sampson.zip',sampFile)
 sampData<-read.paj(unz(sampFile,'Sampson.paj'),
                    time.format='networkDynamic',
                    edge.name = 'liked')


### PR DESCRIPTION
* corrected 3rd party urls for pajek data files used in vignette examples and some associated doc links to the github location provided by the authro
* correct documentation warnings flagged by CRAN r-devel