### PR TITLE
Made changes to documentation to avoid an error with the upcoming net…

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload build results
         if: contains(matrix.config.flags, 'binaries') && !failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-binaries
           path: binaries
@@ -243,7 +243,7 @@ jobs:
         
       - name: Upload check results
         if: contains(matrix.config.flags, 'covr') == false && failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 Change Log:
+v0.11.6
+  -changes to the usage statement for the network.extensions.Rd file, which uses the \method{} tag to help R into thinking that the *.active functions are S3 methods.
 v0.11.5
   - update links to .paj example files and fix some documentation warnings
 v0.11.4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: networkDynamic
-Version: 0.11.5
-Date: 2024-11-21
+Version: 0.11.6
+Date: 2026-03-29
 Title: Dynamic Extensions for Network Objects
 Type: Package
-Depends: R (>= 3.0.0), network (>= 1.17.0)
+Depends: R (>= 3.0.0), network (>= 1.20.0)
 Imports: statnet.common, methods, networkLite
 Suggests: testthat
 LinkingTo: network

--- a/man/network.extensions.Rd
+++ b/man/network.extensions.Rd
@@ -23,17 +23,17 @@
   Various core functions from the \link[network]{network} package, with specialized extensions for handling dynamic data.
 }
 \usage{
-get.edgeIDs.active(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
+\method{get.edgeIDs}{active}(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
     alter = NULL, neighborhood = c("out", "in", "combined"), 
     rule = c("any", "all", "earliest", "latest"), na.omit = TRUE, active.default = TRUE)
-get.edges.active(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
+\method{get.edges}{active}(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
     alter = NULL, neighborhood = c("out", "in", "combined"), 
     rule = c("any", "all", "earliest", "latest"), na.omit = TRUE, active.default = TRUE)
-get.neighborhood.active(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
+\method{get.neighborhood}{active}(x, v, onset = NULL, terminus = NULL, length = NULL, at = NULL,
     type = c("out", "in", "combined"), rule = c("any", "all", "earliest", "latest"), 
     na.omit = TRUE, active.default = TRUE)
 
-is.adjacent.active(x, vi, vj, onset = NULL, terminus = NULL, length = NULL, at = NULL, 
+\method{is.adjacent}{active}(x, vi, vj, onset = NULL, terminus = NULL, length = NULL, at = NULL, 
     rule = c("any", "all", "earliest", "latest"), na.omit = FALSE, active.default = TRUE)
 
 \method{network.dyadcount}{active}(x, onset = NULL, terminus = NULL, length = NULL, at = NULL, 


### PR DESCRIPTION
This makes a single set of changes to the usage statement for the network.extensions.Rd file, which uses the \method{} tag to trick R into thinking that the *.active functions are S3 methods.  We actually had some of these treated this way before, but more have been rendered generic in the meantime.